### PR TITLE
Correct preflop Bet Sizings

### DIFF
--- a/src/agent2.py
+++ b/src/agent2.py
@@ -63,14 +63,14 @@ class MCTSNode:
     def get_valid_actions(self, state):
         """Get valid actions for the current state"""
         # For preflop
-        if len(state[6:16]) // 2 == 0:  # No community cards
-            if state[2] == 0:  # No current bet
+        if len(state[7:17]) // 2 == 0:  # No community cards
+            if state[3] == 0:  # No current bet
                 return ["check", "bet"]
             else:
                 return ["fold", "call", "bet"]
         # For postflop
         else:
-            if state[2] == 0:  # No current bet
+            if state[3] == 0:  # No current bet
                 return ["check", "bet"]
             else:
                 return ["fold", "call", "bet"]

--- a/src/ai_trainer.py
+++ b/src/ai_trainer.py
@@ -589,11 +589,12 @@ class PokerGame:
             valid_actions.extend(["call", "bet", "fold"])
         # fmt: on
         max_bet = self.calculate_max_preflop_bet_size()
+
         if self.num_actions == 0:
             min_bet = max(MINIMUM_BET_INCREMENT, self.current_bet * 2)
         else:
             print(f"Calculating min bet: {self.current_bet} - {self.previous_bet}")
-            min_bet = max(MINIMUM_BET_INCREMENT, (self.current_bet - self.previous_bet) * 2)
+            min_bet = max(MINIMUM_BET_INCREMENT, (self.current_bet - self.previous_bet) + self.current_bet)
         max_bet = max(max_bet, min_bet)
 
         max_bet = min(max_bet, self.current_player.chips)
@@ -627,7 +628,6 @@ class PokerGame:
 
             max_bet = min(max_raise, player_chips)
 
-        max_bet = (max_bet // MINIMUM_BET_INCREMENT) * MINIMUM_BET_INCREMENT
         return max_bet
 
     def calculate_max_postflop_bet_size(self, initial_pot):
@@ -679,6 +679,7 @@ class PokerGame:
                 self.current_player.chips -= final_bet_size - self.oop_committed
                 self.pot += final_bet_size - self.oop_committed
                 self.oop_committed = final_bet_size
+                self.previous_bet = self.current_bet
                 self.current_bet = final_bet_size
                 update_bet_size("ip", final_bet_size, self.pot)
         else:

--- a/src/train.py
+++ b/src/train.py
@@ -15,7 +15,7 @@ from metrics import loss as loss_metric, winrate, episode_reward, cumulative_rew
 
 setup_logging()
 
-STATE_SIZE = 7 + (5*2) + 2*4*2  # Game state features
+STATE_SIZE = 8 + (5*2) + 2*4*2  # Game state features
 ACTION_SIZE = 4  # Available actions
 BATCH_SIZE = 512
 


### PR DESCRIPTION
Previous issues with min/max bet being incorrectly set.

Added new state member `previous_state` 
  Caused issue with MCTS looking at wrong vector indexes resulting in infinite loop due to invalid actions being marked           valid (RESOLVED)
  
